### PR TITLE
adding continuation flag to keylists

### DIFF
--- a/lib/bucket.js
+++ b/lib/bucket.js
@@ -146,10 +146,10 @@ Bucket.prototype.search.twoi = function(twoi_query, index, options, _return) {
     }
 
     if(_return) {  // don't return stream
-        _this.client._bucket.twoi(_this.name, twoi_query, index, options, function(err, results) {
+        _this.client._bucket.twoi(_this.name, twoi_query, index, options, function(err, results, continuation) {
             if(err) _return(err, results);
             else {
-                _return(err, helpers.removeDuplicates(results));
+                _return(err, helpers.removeDuplicates(results), continuation);
             }
         });
     }


### PR DESCRIPTION
allows access to continuation flag for non streaming 2i queries.
