### PR TITLE
Fix agentkeepalive version to 0.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "deepmerge": ">=0.2.5",
         "async": ">=0.2.5",
         "trustfund": ">=0.1.0",
-        "agentkeepalive": ">=0.2.2"
+        "agentkeepalive": "0.2.2"
     },
     "devDependencies": {
         "mocha": "*",


### PR DESCRIPTION
The latest agentkeepalive version (1.0.0) only works with node v0.11+.
Change package.json to pull version 0.2.2 as it is the last version to
support node v0.10.
